### PR TITLE
added not-found.tsx page code

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,5 +1,18 @@
+import Link from "next/link";
+
 const NotFound = () => {
-  return <div>404 Page Not Found</div>;
+  return (
+    <div className="flex flex-grow flex-col items-center justify-center gap-4">
+      <div className="flex text-6xl font-bold md:text-9xl">404</div>
+      <div className="flex text-2xl font-bold md:text-4xl">Page Not Found</div>
+
+      <Link className="mt-6" href="/">
+        <button className="rounded border px-4 py-2 font-bold">
+          Back to Home
+        </button>
+      </Link>
+    </div>
+  );
 };
 
 export default NotFound;


### PR DESCRIPTION
I have added the code for `not-found.tsx` page.

## code
```tsx
import Link from "next/link";

const NotFound = () => {
  return (
    <div className="flex flex-grow flex-col items-center justify-center gap-4">
      <div className="flex text-6xl font-bold md:text-9xl">404</div>
      <div className="flex text-2xl font-bold md:text-4xl">Page Not Found</div>

      <Link className="mt-6" href="/">
        <button className="rounded border px-4 py-2 font-bold">
          Back to Home
        </button>
      </Link>
    </div>
  );
};

export default NotFound;
```
## screenshot
![ss-20240930-081150Z-current](https://github.com/user-attachments/assets/f803a983-47b8-4dd7-8dd2-c5e860c5b025)