### PR TITLE
Add mission statement 

### DIFF
--- a/src/components/home/Mission.tsx
+++ b/src/components/home/Mission.tsx
@@ -1,8 +1,8 @@
 const Mission = () => {
   return (
     <div className="bg-[#b35644] p-10 rounded-lg text-center max-w-lg mx-auto">
-      <h1></h1>
-      <p></p>
+      <h1 className="text-white text-3xl font-bold mb-6">MISSION STATEMENT</h1>
+      <p className=""></p>
     </div>
   );
 };

--- a/src/components/home/Mission.tsx
+++ b/src/components/home/Mission.tsx
@@ -1,7 +1,9 @@
 const Mission = () => {
   return (
     <div className="mx-auto max-w-lg rounded-lg bg-[#a12424] p-10 text-center">
-      <h1 className="mb-6 text-3xl font-normal text-white">MISSION STATEMENT</h1>
+      <h1 className="mb-6 text-3xl font-normal text-white">
+        MISSION STATEMENT
+      </h1>
       <p className="text-lg leading-relaxed text-white">
         It provides opportunities for service, professional development, and
         interaction among its members and financial professionals. Additionally,

--- a/src/components/home/Mission.tsx
+++ b/src/components/home/Mission.tsx
@@ -1,11 +1,12 @@
 const Mission = () => {
   return (
-    <div className="bg-[#b35644] p-10 rounded-lg text-center max-w-lg mx-auto">
-      <h1 className="text-white text-3xl font-bold mb-6">MISSION STATEMENT</h1>
-      <p className="text-white text-lg leading-relaxed">
-        It provides opportunities for service, professional development, and interaction among its members and financial professionals. 
-        Additionally, Beta Alpha Psi fosters lifelong ethical, social, and public responsibilities, shaping its members into leaders 
-        in their fields.
+    <div className="mx-auto max-w-lg rounded-lg bg-[#b35644] p-10 text-center">
+      <h1 className="mb-6 text-3xl font-bold text-white">MISSION STATEMENT</h1>
+      <p className="text-lg leading-relaxed text-white">
+        It provides opportunities for service, professional development, and
+        interaction among its members and financial professionals. Additionally,
+        Beta Alpha Psi fosters lifelong ethical, social, and public
+        responsibilities, shaping its members into leaders in their fields.
       </p>
     </div>
   );

--- a/src/components/home/Mission.tsx
+++ b/src/components/home/Mission.tsx
@@ -1,6 +1,6 @@
 const Mission = () => {
   return (
-    <div className="mx-auto max-w-lg rounded-lg bg-[#a12424] p-10 text-center">
+    <div className="mx-auto max-w-lg bg-[#a12424] p-10 text-center">
       <h1 className="mb-6 text-3xl font-normal text-white">
         MISSION STATEMENT
       </h1>

--- a/src/components/home/Mission.tsx
+++ b/src/components/home/Mission.tsx
@@ -1,7 +1,7 @@
 const Mission = () => {
   return (
-    <div className="mx-auto max-w-lg bg-[#a12424] px-10 pb-10 pt-0 text-center">
-      <h1 className="mb-6 text-3xl font-normal text-white">
+    <div className="mx-auto max-w-lg bg-[#a12424] px-10 pb-10 pt-10 text-center">
+      <h1 className="mb-6 text-4xl font-thin text-white">
         MISSION STATEMENT
       </h1>
       <p className="text-lg leading-relaxed text-white">

--- a/src/components/home/Mission.tsx
+++ b/src/components/home/Mission.tsx
@@ -1,6 +1,6 @@
 const Mission = () => {
   return (
-    <div className="mx-auto max-w-lg rounded-lg bg-[#b35644] p-10 text-center">
+    <div className="mx-auto max-w-lg rounded-lg bg-[#a12424] p-10 text-center">
       <h1 className="mb-6 text-3xl font-bold text-white">MISSION STATEMENT</h1>
       <p className="text-lg leading-relaxed text-white">
         It provides opportunities for service, professional development, and

--- a/src/components/home/Mission.tsx
+++ b/src/components/home/Mission.tsx
@@ -1,6 +1,6 @@
 const Mission = () => {
   return (
-    <div className="mx-auto max-w-lg bg-[#a12424] p-10 text-center">
+    <div className="mx-auto max-w-lg bg-[#a12424] px-10 pb-10 pt-0 text-center">
       <h1 className="mb-6 text-3xl font-normal text-white">
         MISSION STATEMENT
       </h1>

--- a/src/components/home/Mission.tsx
+++ b/src/components/home/Mission.tsx
@@ -1,7 +1,7 @@
 const Mission = () => {
   return (
     <div className="mx-auto max-w-lg rounded-lg bg-[#a12424] p-10 text-center">
-      <h1 className="mb-6 text-3xl font-bold text-white">MISSION STATEMENT</h1>
+      <h1 className="mb-6 text-3xl font-normal text-white">MISSION STATEMENT</h1>
       <p className="text-lg leading-relaxed text-white">
         It provides opportunities for service, professional development, and
         interaction among its members and financial professionals. Additionally,

--- a/src/components/home/Mission.tsx
+++ b/src/components/home/Mission.tsx
@@ -1,9 +1,7 @@
 const Mission = () => {
   return (
     <div className="mx-auto max-w-lg bg-[#a12424] px-10 pb-10 pt-10 text-center">
-      <h1 className="mb-6 text-4xl font-thin text-white">
-        MISSION STATEMENT
-      </h1>
+      <h1 className="mb-6 text-4xl font-thin text-white">MISSION STATEMENT</h1>
       <p className="text-lg leading-relaxed text-white">
         It provides opportunities for service, professional development, and
         interaction among its members and financial professionals. Additionally,

--- a/src/components/home/Mission.tsx
+++ b/src/components/home/Mission.tsx
@@ -1,7 +1,8 @@
 const Mission = () => {
   return (
-    <div className="">
-      <p>Mission</p>
+    <div className="bg-[#b35644] p-10 rounded-lg text-center max-w-lg mx-auto">
+      <h1></h1>
+      <p></p>
     </div>
   );
 };

--- a/src/components/home/Mission.tsx
+++ b/src/components/home/Mission.tsx
@@ -2,7 +2,11 @@ const Mission = () => {
   return (
     <div className="bg-[#b35644] p-10 rounded-lg text-center max-w-lg mx-auto">
       <h1 className="text-white text-3xl font-bold mb-6">MISSION STATEMENT</h1>
-      <p className=""></p>
+      <p className="text-white text-lg leading-relaxed">
+        It provides opportunities for service, professional development, and interaction among its members and financial professionals. 
+        Additionally, Beta Alpha Psi fosters lifelong ethical, social, and public responsibilities, shaping its members into leaders 
+        in their fields.
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
Pull Request Info:
Adds the Mission Statement component from BAP for the homepage and applies several stylistic changes to the intended design. 

Changes/Adjustments:
- Background color (#a12424) is set to a darker pastel red.
- Font Color (White) for clear readability and to match the intended design.
- Container Styling (pt-0 pb-10 px-10) and centered the text for precision alignment (text-center).

Problem Addressed: 
The homepage previously had no content on it for the Mission Statement of BAP, now users can see the statement from BAP, which ultimately is one of the most important pieces for an organization. 
<img width="1710" alt="Screenshot 2024-10-13 at 10 11 24 PM" src="https://github.com/user-attachments/assets/ff79a3db-e545-46d5-8ca1-c8d57ee47aa5">
<img width="1708" alt="Screenshot 2024-10-13 at 10 12 13 PM" src="https://github.com/user-attachments/assets/0b2e3168-5034-4f49-be75-e5844fe50bb7">
