### PR TITLE
Add 2nd Half of Mission Statement

### DIFF
--- a/src/components/home/Mission.tsx
+++ b/src/components/home/Mission.tsx
@@ -21,7 +21,6 @@ const Mission = () => {
       </div>
 
       <div className="absolute bottom-0 left-1/2 flex h-[100px] w-[600px] -translate-x-1/2 transform items-center justify-center bg-[#b4966fa4] p-4 text-center text-2xl text-white">
-        
         “Knowledge Is The Key To Opening The Doors Of The Financial World”
       </div>
     </div>

--- a/src/components/home/Mission.tsx
+++ b/src/components/home/Mission.tsx
@@ -20,7 +20,8 @@ const Mission = () => {
         </p>
       </div>
 
-      <div className="">
+      <div className="absolute bottom-0 left-1/2 flex h-[100px] w-[600px] -translate-x-1/2 transform items-center justify-center bg-[#b4966fa4] p-4 text-center text-2xl text-white">
+        
         “Knowledge Is The Key To Opening The Doors Of The Financial World”
       </div>
     </div>

--- a/src/components/home/Mission.tsx
+++ b/src/components/home/Mission.tsx
@@ -1,13 +1,28 @@
 const Mission = () => {
   return (
-    <div className="mx-auto max-w-lg bg-[#a12424] px-10 pb-10 pt-10 text-center">
-      <h1 className="mb-6 text-4xl font-thin text-white">MISSION STATEMENT</h1>
-      <p className="text-lg leading-relaxed text-white">
-        It provides opportunities for service, professional development, and
-        interaction among its members and financial professionals. Additionally,
-        Beta Alpha Psi fosters lifelong ethical, social, and public
-        responsibilities, shaping its members into leaders in their fields.
-      </p>
+    <div className="relative h-full w-full">
+      <img
+        src="/clubimage2.webp"
+        alt="Club Image"
+        className="h-full w-full object-cover"
+      />
+
+      <div className="absolute left-0 top-0 max-w-lg bg-[#a12424] px-10 pb-20 pt-10 text-center">
+        <h1 className="mb-6 text-4xl font-thin text-white">
+          MISSION STATEMENT
+        </h1>
+        <p className="text-lg leading-relaxed text-white">
+          It provides opportunities for service, professional development, and
+          interaction among its members and financial professionals.
+          Additionally, Beta Alpha Psi fosters lifelong ethical, social, and
+          public responsibilities, shaping its members into leaders in their
+          fields.
+        </p>
+      </div>
+
+      <div className="">
+        “Knowledge Is The Key To Opening The Doors Of The Financial World”
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Changes Implemented:
- Added club image from the public folder 
- Added text box to the bottom of the page as shown in the intended product 
- Used absolute positioning 

<img width="1708" alt="Screenshot 2024-10-13 at 10 12 13 PM" src="https://github.com/user-attachments/assets/ac77c661-8482-45e7-8e53-647c1288812d">
<img width="1370" alt="Screenshot 2024-10-21 at 2 15 30 PM" src="https://github.com/user-attachments/assets/2928b4db-0de2-4d58-b610-8df7b5f31e9f">
