### PR TITLE
Modified layout of home page red box to match design

### DIFF
--- a/src/components/home/Membership.tsx
+++ b/src/components/home/Membership.tsx
@@ -1,13 +1,13 @@
 const Membership = () => {
   return (
-    <div className="flex-col bg-bap-red-200 px-3 py-2.5 text-center">
-      <p className="text-2xl"> MEMBERSHIP</p>
-      <p className="text-xs">
+    <div className="w-100 flex-col bg-bap-red-200 px-10 py-20 text-center">
+      <p className="relative -top-6 text-5xl"> MEMBERSHIP</p>
+      <p className="mx-auto max-w-xl text-wrap text-center text-lg">
         Lorem Ipsum Dolor Sit Amet, Consectetur Adipiscing Elit, Sed Do Eiusmod
         Tempor Incididunt Ut Labore Et Dolore Magna Aliqua
       </p>
       <button>
-        <p className="rounded-sm bg-bap-brown-100 bg-opacity-[34%] px-4 py-2.5 text-center text-lg shadow-md shadow-black">
+        <p className="relative -bottom-6 rounded-sm bg-bap-brown-100 bg-opacity-[34%] px-12 py-3 text-center text-3xl shadow-md shadow-black">
           Join Us
         </p>
       </button>


### PR DESCRIPTION
Edited the layout of the home page red box so it fits the whole page and the text was resized, aligned, and spaced between the box similar to the design.

![Screenshot 2024-11-08 142725](https://github.com/user-attachments/assets/ef0ee127-5a58-470b-a4d9-4d692ab0027e)
