### PR TITLE
139 fix navbar selection underline

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -43,8 +43,11 @@ const Navigation = () => {
       className="w-full items-center justify-between pt-4"
     >
       <Navbar.Brand className="pl-8">
-        <Link className="flex items-center space-x-4 no-underline" href="/"
-        onClick = {handleBAPClick}>
+        <Link
+          className="flex items-center space-x-4 no-underline"
+          href="/"
+          onClick={handleBAPClick}
+        >
           <Image className="w-20" src={logo} alt="Beta Alpha Psi Logo" />
           <div className="xl:text-5x text-4xl font-normal text-white">
             BETA ALPHA PSI
@@ -89,11 +92,13 @@ const Navigation = () => {
                     className="flex items-center pl-2 pr-2 text-white hover:bg-gray-700"
                     onClick={toggleDropdown}
                   >
-                    <div className={`font-light ${
-                    isResourcesActive
-                      ? "underline underline-offset-8"
-                      : ""
-                    }`}>{item.name}</div>
+                    <div
+                      className={`font-light ${
+                        isResourcesActive ? "underline underline-offset-8" : ""
+                      }`}
+                    >
+                      {item.name}
+                    </div>
                     <style>
                       {`
                           .dropdown-toggle:after {
@@ -126,7 +131,7 @@ const Navigation = () => {
                         as={Link}
                         key={index}
                         href={page.link}
-                        onClick={ () => {
+                        onClick={() => {
                           toggleDropdown();
                           handleResourceClick(page.link);
                         }}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -14,9 +14,21 @@ const Navigation = () => {
   const [activePath, setActivePath] = useState("");
   // determines if dropdown has been opened; set false at start
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isResourcesActive, setIsResourcesActive] = useState(false);
 
   const handleNavClick = (Path: string) => {
     setActivePath(Path);
+    setIsResourcesActive(false);
+  };
+
+  const handleResourceClick = (Path: string) => {
+    setIsResourcesActive(true);
+    setActivePath(Path);
+  };
+
+  const handleBAPClick = () => {
+    setActivePath("");
+    setIsResourcesActive(false);
   };
 
   // function changes boolean of isDropdownOpen
@@ -31,7 +43,8 @@ const Navigation = () => {
       className="w-full items-center justify-between pt-4"
     >
       <Navbar.Brand className="pl-8">
-        <Link className="flex items-center space-x-4 no-underline" href="/">
+        <Link className="flex items-center space-x-4 no-underline" href="/"
+        onClick = {handleBAPClick}>
           <Image className="w-20" src={logo} alt="Beta Alpha Psi Logo" />
           <div className="xl:text-5x text-4xl font-normal text-white">
             BETA ALPHA PSI
@@ -76,7 +89,11 @@ const Navigation = () => {
                     className="flex items-center pl-2 pr-2 text-white hover:bg-gray-700"
                     onClick={toggleDropdown}
                   >
-                    <div className="font-light">{item.name}</div>
+                    <div className={`font-light ${
+                    isResourcesActive
+                      ? "underline underline-offset-8"
+                      : ""
+                    }`}>{item.name}</div>
                     <style>
                       {`
                           .dropdown-toggle:after {
@@ -109,7 +126,15 @@ const Navigation = () => {
                         as={Link}
                         key={index}
                         href={page.link}
-                        onClick={toggleDropdown}
+                        onClick={ () => {
+                          toggleDropdown();
+                          handleResourceClick(page.link);
+                        }}
+                        className={`${
+                          activePath === page.link
+                            ? "underline underline-offset-8"
+                            : ""
+                        }`}
                       >
                         {" " + page.name + " "}
                       </NavDropdown.Item>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -89,7 +89,7 @@ const Navigation = () => {
                 key={index}
                 title={
                   <div
-                    className="flex items-center pl-2 pr-2 text-white hover:bg-gray-700"
+                    className="flex items-center pl-2 pr-2 text-white"
                     onClick={toggleDropdown}
                   >
                     <div


### PR DESCRIPTION
![Screenshot 2024-12-01 163303](https://github.com/user-attachments/assets/0b97d6f8-585f-4850-aa69-5cc49488b4ed)
when resource page is clicked, resources in navbar should be underlined, also if BAP (main page) is clicked, nothing should be underlined anymore.